### PR TITLE
Require only lower version of gtk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ uuid = { version = "0.4", features = ["serde"] }
 serde = "0.9"
 serde_derive = "0.9"
 serde_json = "0.9"
-gtk = { version = "0.1.3", default-features = false,features = ["v3_22"]}
+gtk = { version = "0.1.3", default-features = false,features = ["v3_18"]}
 gdk = { version = "0.5.3", default-features = false}
 glib = { version = "0.1.3", default-features = false}
 regex = "0.2"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I do not promise that there will come any more features. But a lot comes to mind
 ### Run Requirements
 
 * taskwarrior >= 2.5
-* gtk >=3.22
+* gtk >=3.18
 
 ### Install
 

--- a/src/tasklist.glade
+++ b/src/tasklist.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.18"/>
   <object class="GtkEntryBuffer" id="filterbuffer">
     <property name="text" translatable="yes">+PENDING</property>
   </object>


### PR DESCRIPTION
I only have 3.18 and it seems to work just fine.